### PR TITLE
Feature nav-tabs

### DIFF
--- a/addon/components/nav-tabs.js
+++ b/addon/components/nav-tabs.js
@@ -1,0 +1,8 @@
+import Component from '@ember/component';
+import layout from '../templates/components/nav-tabs';
+
+export default Component.extend({
+  layout,
+  tagName: 'nav',
+  classNames: ['tradegecko-ui-nav-tabs'],
+});

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -3,3 +3,4 @@
 @import 'components/site-header';
 @import 'components/progress-bar';
 @import 'components/action-sheet';
+@import 'components/nav-tabs';

--- a/addon/styles/components/_nav-tabs.scss
+++ b/addon/styles/components/_nav-tabs.scss
@@ -1,12 +1,14 @@
+$tabs-border-color: #c4ced1;
 $tab-padding-left: 15px;
 $tab-padding-right: 15px;
 $tab-background-color: #e2e6e8;
 $tab-line-height: 32px;
-$active-tab-line-height: 34px;
-$active-tab-border-color: #c4ced1;
+$active-tab-line-height: 35px;
+$active-tab-border-radius: 2px;
 
 .tradegecko-ui-nav-tabs {
   display: flex;
+  border-bottom: 1px solid $tabs-border-color;
 
   &__tab {
     align-self: flex-end;
@@ -23,7 +25,11 @@ $active-tab-border-color: #c4ced1;
     }
 
     &.active {
-      border-color: $active-tab-border-color;
+      position: relative;
+      bottom: -1px;
+      border-top-left-radius: $active-tab-border-radius;
+      border-top-right-radius: $active-tab-border-radius;
+      border-color: $tabs-border-color;
       background-color: #fff;
       line-height: $active-tab-line-height;
     }

--- a/addon/styles/components/_nav-tabs.scss
+++ b/addon/styles/components/_nav-tabs.scss
@@ -1,0 +1,31 @@
+$tab-padding-left: 15px;
+$tab-padding-right: 15px;
+$tab-background-color: #e2e6e8;
+$tab-line-height: 32px;
+$active-tab-line-height: 34px;
+$active-tab-border-color: #c4ced1;
+
+.tradegecko-ui-nav-tabs {
+  display: flex;
+
+  &__tab {
+    align-self: flex-end;
+    padding-left: $tab-padding-left;
+    padding-right: $tab-padding-right;
+    background-color: $tab-background-color;
+    color: inherit;
+    border: 1px solid transparent;
+    border-bottom: 0;
+    line-height: $tab-line-height;
+
+    &:not(.active) + .tradegecko-ui-nav-tabs__tab {
+      border-left-color: #fff;
+    }
+
+    &.active {
+      border-color: $active-tab-border-color;
+      background-color: #fff;
+      line-height: $active-tab-line-height;
+    }
+  }
+}

--- a/addon/templates/components/nav-tabs.hbs
+++ b/addon/templates/components/nav-tabs.hbs
@@ -1,0 +1,3 @@
+{{yield (hash
+  link=(component "link-to" classNames="tradegecko-ui-nav-tabs__tab")
+)}}

--- a/tests/integration/components/nav-tabs-test.js
+++ b/tests/integration/components/nav-tabs-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | nav-links', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{nav-links}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#nav-links}}
+        template block text
+      {{/nav-links}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
### Usage

```hbs
{{#tradegecko-ui-nav-tabs as |navs|}}
  {{#navs.link "pick"}}To Pick{{/navs.link}}
  {{#navs.link "pack"}}To Pack{{/navs.link}}
  {{#navs.link "packed"}}Packed{{/navs.link}}
{{/tradegecko-ui-nav-tabs}}

```


### Screenshot

<img width="421" alt="screen shot 2018-08-01 at 4 37 47 pm" src="https://user-images.githubusercontent.com/2162441/43510777-42737dc6-95a9-11e8-90c4-b3f705d60795.png">
