### PR TITLE
[BUGFIX] Explicitly set buttonn foxus border

### DIFF
--- a/addon/styles/components/_button.scss
+++ b/addon/styles/components/_button.scss
@@ -57,6 +57,9 @@ $button-types: (
         color: map-get($type, disabled-color);
         background-color: map-get($type, disabled-background-color);
       }
+      &:focus {
+        border: 1px solid #70cf32;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Summary
Rango, Pacman (and everything else) explicitly overrides `button:focus` in `layout.scss` the file.
https://github.com/tradegecko/tradegecko-warehousing/pull/1/commits/a47d15666b50c13cb1b831ed3f845cb263da271e made our button an actually button which clashed.

#### Screenshots
hard to take shots of focus unfocus because they make no sense.