### PR TITLE
[Feature] Move color variables to the addon

### DIFF
--- a/app/styles/@tradegecko/warehousing/variables/base-colors.scss
+++ b/app/styles/@tradegecko/warehousing/variables/base-colors.scss
@@ -1,0 +1,77 @@
+//  brand colours
+$c-moko:   #70cf32;
+
+$white:    #ffffff;
+$gray-1:   #f4f4f5; //$c-hilton
+$gray-2:   #e2e6e8; //$c-sanfran
+$gray-3:   #c4ced1; //$c-newyork
+$gray-4:   #a4aeb3; //$c-london
+$gray-5:   #889096; //$c-glencoe
+$gray-6:   #6c7279; //$c-storm
+$gray-7:   #585d64; //$c-beijing
+$gray-8:   #393c40; //$c-shanghai
+$gray-9:   #2d3033; //$c-slate
+$gray-10:  #242629; //$c-delhi
+$c-black:    #000000;
+
+//  cta colours
+$c-oops-light:         #fccc0a;
+$c-oops:               #fbb207;
+$c-oops-dark:          #e6a306;
+
+$c-mayhem-light:       #dc2828;
+$c-mayhem:             #c61c1c;
+$c-mayhem-dark:        #b51919;
+
+//  Zoning colours
+$c-dragonfruit-light:  #ea2fa1;
+$c-dragonfruit:        #db2182;
+$c-dragonfruit-dark:   #c81e77;
+
+$c-baby-light:         #f56bbf;
+$c-baby:               #ed50a2;
+$c-baby-dark:          #c81e77;
+
+$c-haze-light:         #bd74d1;
+$c-haze:               #a058b8;
+$c-haze-dark:          #9250a8;
+
+$c-royal-light:        #767ee1;
+$c-royal:              #5960ce;
+$c-royal-dark:         #5158bd;
+
+$c-vhs-light:          #285e7f;
+$c-vhs:                #1c4561;
+$c-vhs-dark:           #193f59;
+
+$c-ocean-light:        #5ab9e1;
+$c-ocean:              #429bce;
+$c-ocean-dark:         #3c8ebd;
+
+$c-sky-light:          #8ee6e9;
+$c-sky:                #6fd5d9;
+$c-sky-dark:           #65c3c7;
+
+$c-surf-light:         #9aefd5;
+$c-surf:               #7be3bd;
+$c-surf-dark:          #70d0ad;
+
+$c-moko-light:         #8fe246;
+//-moko
+$c-moko-dark:          #2fb628;
+
+$c-snot-light:         #ccf111;
+$c-snot:               #b2e60c;
+$c-snot-dark:          #a3d30b;
+
+$c-prosper-light:      #f5ed33;
+$c-prosper:            #eedf24;
+$c-prosper-dark:       #dacc21;
+
+$c-watermelon-light:   #fa7367;
+$c-watermelon:         #f6574d;
+$c-watermelon-dark:    #e14f46;
+
+$c-elite-light:        #e3c63c;
+$c-elite:              #d0aa2b;
+$c-elite-dark:         #c09146; // used to be #d0b537;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
+    sassOptions: {
+      includePaths: ['app/styles'],
+    }
   });
   /*
     This build file specifies the options for the dummy test app of this


### PR DESCRIPTION
Move the color variables to the tradegecko-warehousing addon

In the consuming app,

```sass
@import '@tradegecko/warehousing/variables/base-colors';
```
