### PR TITLE
Overrides ember-content-placeholders styles

### DIFF
--- a/addon/templates/components/loading-state-placeholder.hbs
+++ b/addon/templates/components/loading-state-placeholder.hbs
@@ -1,5 +1,5 @@
 {{#each this.numberOfYields as |count|}}
-  {{#content-placeholders class="tradegecko-ui-loading-state-placeholder" as |placeholder|}}
+  {{#content-placeholders animated=false class="tradegecko-ui-loading-state-placeholder" as |placeholder|}}
     {{yield placeholder}}
   {{/content-placeholders}}
 {{/each}}

--- a/app/styles/@tradegecko/warehousing/addons.scss
+++ b/app/styles/@tradegecko/warehousing/addons.scss
@@ -3,6 +3,7 @@
 @import 'icons';
 @import 'vendor/variables/ember-content-placeholders';
 @import 'vendor/ember-content-placeholders';
+@import 'vendor/ember-content-placeholders-overrides';
 
 @import 'components/button';
 @import 'components/alert-box';

--- a/app/styles/@tradegecko/warehousing/vendor/ember-content-placeholders-overrides.scss
+++ b/app/styles/@tradegecko/warehousing/vendor/ember-content-placeholders-overrides.scss
@@ -1,0 +1,17 @@
+.ember-content-placeholders-text__line {
+  &:nth-child(4n + 1) {
+    width: 100%;
+  }
+
+  &:nth-child(4n + 2) {
+    width: 80%;
+  }
+
+  &:nth-child(4n + 3) {
+    width: 60%;
+  }
+
+  &:nth-child(4n + 4) {
+    width: 40%;
+  }
+}

--- a/app/styles/@tradegecko/warehousing/vendor/variables/ember-content-placeholders.scss
+++ b/app/styles/@tradegecko/warehousing/vendor/variables/ember-content-placeholders.scss
@@ -1,3 +1,4 @@
-$ember-content-placeholders-line-height: 14px;
-$ember-content-placeholders-primary-color: #ccc;
-$ember-content-placeholders-secondary-color: #f3f3f3;
+$ember-content-placeholders-line-height: 10px;
+$ember-content-placeholders-spacing: 14px;
+$ember-content-placeholders-primary-color: #f4f4f5;
+$ember-content-placeholders-secondary-color: #f4f4f5;


### PR DESCRIPTION
#### Before
<img width="521" alt="screen shot 2018-08-15 at 2 18 23 pm" src="https://user-images.githubusercontent.com/2162441/44134171-21927d12-a096-11e8-9048-efc4cbe98011.png">

#### After
<img width="504" alt="screen shot 2018-08-15 at 2 17 52 pm" src="https://user-images.githubusercontent.com/2162441/44134170-2161468e-a096-11e8-8af8-2c70d40c389e.png">
