### PR TITLE
Add sidebar nav to addon docs

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,20 @@ Router.map(function() {
   docsRoute(this, function() {
     /* Your docs routes go here */
     this.route('components', function() {
+      this.route('buttons');
+      this.route('alertBox');
+      this.route('checkBox');
+      this.route('detailsBlock');
+      this.route('emptyList');
+      this.route('freeformLineItem');
+      this.route('loadingStatePlaceholder');
+      this.route('navTabs');
+      this.route('progressBar');
+      this.route('quantityInputModal');
+      this.route('scannerIncrementModal');
+      this.route('siteHeader');
+      this.route('statusTag');
+      this.route('summeryLineItem');
     });
   });
   this.route('not-found', { path: '/*path' });

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -1,0 +1,26 @@
+{{#docs-viewer as |viewer|}}
+  {{#viewer.nav as |nav|}}
+    {{nav.section 'Components'}}
+    {{nav.item "Buttons" "docs.components.buttons"}}
+    {{nav.item "Alert Boxes" "docs.components.alertBox"}}
+    {{nav.item "Checkbox" "docs.components.checkBox"}}
+    {{nav.item "Details Block" "docs.components.detailsBlock"}}
+    {{nav.item "Empty List" "docs.components.emptyList"}}
+    {{nav.item "Freeform Line Item" "docs.components.freeformLineItem"}}
+    {{nav.item "Loading State Placeholder" "docs.components.loadingStatePlaceholder"}}
+    {{nav.item "Nav Tabs" "docs.components.navTabs"}}
+    {{nav.item "Progress Bar" "docs.components.progressBar"}}
+    {{nav.item "Quantity Input Modal" "docs.components.quantityInputModal"}}
+    {{nav.item "Scanner Increment Modal" "docs.components.scannerIncrementModal"}}
+    {{nav.item "Site Header" "docs.components.siteHeader"}}
+    {{nav.item "Status Tag" "docs.components.statusTag"}}
+    {{nav.item "Summary Line Item" "docs.components.summeryLineItem"}}
+  {{/viewer.nav}}
+   {{#viewer.main}}
+    <div class="docs-container">
+      <div class="docs-section">
+        {{outlet}}
+      </div>
+    </div>
+  {{/viewer.main}}
+{{/docs-viewer}}

--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -1,0 +1,3 @@
+# Introduction
+
+Use the navigator to view how the components look like


### PR DESCRIPTION
Added a sidebar nav to `/docs` page.

<img width="1440" alt="screen shot 2018-10-30 at 8 43 59 pm" src="https://user-images.githubusercontent.com/1717441/47718944-ae211e80-dc84-11e8-99ad-ee016e1e9579.png">
