### PR TITLE
Ignore uglifier for deploy

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,16 @@ module.exports = function(defaults) {
     sassOptions: {
       includePaths: ['app/styles'],
     },
+    minifyJS: {
+      options: {
+        exclude: ["**/vendor.js"],
+      },
+    },
+    'ember-cli-uglify': {
+      uglify: {
+        compress: false, // added this to workaround the issue
+      },
+    },
   });
   /*
     This build file specifies the options for the dummy test app of this

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "ember-content-placeholders": "^1.0.0",
     "ember-wormhole": "^0.5.4"
   },
+  "resolutions": {
+    "uglify-es": "^3.3.9"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",


### PR DESCRIPTION
Without this change, broccoli throws an error in the Production build