### PR TITLE
Prop types is a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-sass": "^7.1.7",
     "ember-content-placeholders": "^1.0.0",
-    "ember-wormhole": "^0.5.4"
+    "ember-wormhole": "^0.5.4",
+    "ember-prop-types": "^7.0.4"
   },
   "resolutions": {
     "uglify-es": "^3.3.9"
@@ -49,7 +50,6 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-prop-types": "^7.0.4",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.2.0-beta.2",
     "ember-source-channel-url": "^1.0.1",


### PR DESCRIPTION
Not all apps that install this have `ember-prop-types` so it should be  a dependecy